### PR TITLE
to support mutates = false on Framework.

### DIFF
--- a/assembly/deps/as-scale-codec/interfaces/Codec.ts
+++ b/assembly/deps/as-scale-codec/interfaces/Codec.ts
@@ -18,6 +18,7 @@
  * The base Codec interface. All supported types by the library must implement this interface.
  * This interface represents the base functions required by every encoding/decoding of types
  */
+
 export interface Codec {
 
     /**
@@ -38,7 +39,7 @@ export interface Codec {
 
     /**
      * Checks if an instance is equal with other instance
-     * @param other other instance     
+     * @param other other instance
     */
     eq(other: Codec): bool;
 

--- a/assembly/storage/storage.ts
+++ b/assembly/storage/storage.ts
@@ -11,14 +11,25 @@ import { ReadBuffer } from "../primitives/readbuffer";
 import { WriteBuffer } from "../primitives/writebuffer";
 import { Crypto } from "../primitives/crypto";
 
+export enum StoreMode {W = 0, R = 1, WR = 2}
+
 export class Storage<T extends Codec> {
+  // store mode, to limit store value to native in `mutates = false`
+  private static sStoreMode: StoreMode = StoreMode.WR;
+  static set mode(mode: StoreMode) {
+    Storage.sStoreMode = mode;
+  }
+
   private key: string;
 
   constructor(_key: string) {
     this.key = _key;
   }
 
+
   store(value: T): ReturnCode {
+    assert(Storage.sStoreMode != StoreMode.R, "Storage: only read allowed");
+
     const buf = new WriteBuffer(value.toU8a().buffer);
     seal_set_storage(
       this.hashKey(),

--- a/examples/preprocess/target.ts
+++ b/examples/preprocess/target.ts
@@ -4,11 +4,12 @@
  */
 
 import { Bool } from "as-scale-codec";
-import { Storage } from "../../assembly/storage";
+import { Storage, StoreMode } from "../../assembly/storage";
 import { Log } from "../../assembly/utils/Log";
 import { ReturnData } from "../../assembly/primitives/returndata";
 import { Msg } from "../../assembly/buildins/Msg";
 import { FnParameters } from "../../assembly/buildins/FnParameters";
+import { u128 } from "../../assembly";
 
 // storage class should be implemented by preprocessor automatilly like auto load and save.
 // Besides these primitives types, any composite type like classes embeded,
@@ -49,13 +50,13 @@ class Flipper {
   }
 
   flip(): void {
-    assert(msg.notPayable(), "Can not accept value");
+    assert(msg.value == u128.Zero, "method is not payable");
     const v = this.stored.flag;
     this.stored.flag = !v;
   }
 
   get(): bool {
-    assert(msg.notPayable(), "Can not accept value");
+    Storage.mode = StoreMode.R;
     return this.stored.flag;
   }
 
@@ -63,7 +64,7 @@ class Flipper {
   }
 
   specific(): void {
-    assert(msg.notPayable(), "Can not accept value");
+    assert(msg.value == u128.Zero, "method is not payable");
   }
 }
 


### PR DESCRIPTION
Preprocessor should generate control logic for mutates = false.